### PR TITLE
WIP: Fix build and tests stage

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -19,6 +19,10 @@ stages:
       GOOS: linux
       GOGC: off
     commands:
+    - apk -U add curl
+    - curl -sL https://go.kubebuilder.io/dl/2.2.0/linux/amd64 | tar -xz -C /tmp/
+    - mv /tmp/kubebuilder_2.2.0_linux_amd64 /usr/local/kubebuilder
+    - export PATH=$PATH:/usr/local/kubebuilder/bin
     - go test ./...
     - go build -a -installsuffix cgo -ldflags "-X main.appgroup=${ESTAFETTE_LABEL_APP_GROUP} -X main.app=${ESTAFETTE_GIT_NAME} -X main.version=${ESTAFETTE_BUILD_VERSION} -X main.revision=${ESTAFETTE_GIT_REVISION} -X main.branch=${ESTAFETTE_GIT_BRANCH} -X main.buildDate=${ESTAFETTE_BUILD_DATETIME}" -o ./publish/${ESTAFETTE_GIT_NAME} .
 


### PR DESCRIPTION
Not the best approach, just want to keep the idea for now. Later on we should build a docker image with kubebuilder because the tests need some tools like `etcd` and `kubectl`, and they come by default inside the kubebuilder installation.